### PR TITLE
fix(auth): Use env variables for Discord credentials

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -27,8 +27,8 @@ export const authOptions = {
       }
     }),
     DiscordProvider({
-      clientId: "1371192484943892611",
-      clientSecret: "NsUMNKJ5XB1mJ-7w43IPX8s8cfsksHfD",
+      clientId: process.env.DISCORD_CLIENT_ID,
+      clientSecret: process.env.DISCORD_CLIENT_SECRET,
       allowDangerousEmailAccountLinking: true,
       authorization: {
         params: {


### PR DESCRIPTION
- Use environment variables for Discord client ID and secret to resolve OAuth `invalid_client` error.
- Delete unused `src/config.local.ts` which contained outdated, hardcoded credentials.
- This change also revealed a new intermittent database connection issue which we will investigate next.