### PR TITLE
fix: implement automatic slug updates when recipe titles change

### DIFF
--- a/src/app/api/recipes/[id]/route.ts
+++ b/src/app/api/recipes/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getSession, getCurrentUserId } from '@/lib/auth/get-session';
 import { z } from 'zod';
+import { slugify } from '@/lib/utils';
 
 // Validation schema for updating a recipe
 const updateRecipeSchema = z.object({
@@ -119,6 +120,30 @@ export async function PUT(
 
     const { title, instructions, tags = [] } = validationResult.data;
 
+    // Generate new slug if title has changed
+    let newSlug = recipe.slug;
+    if (title !== recipe.title) {
+      newSlug = slugify(title);
+      
+      // Check if the new slug already exists (excluding the current recipe)
+      const existingRecipe = await prisma.recipe.findUnique({
+        where: { slug: newSlug },
+      });
+      
+      if (existingRecipe && existingRecipe.id !== id) {
+        // If slug exists, append a number to make it unique
+        let counter = 1;
+        let uniqueSlug = `${newSlug}-${counter}`;
+        
+        while (await prisma.recipe.findUnique({ where: { slug: uniqueSlug } })) {
+          counter++;
+          uniqueSlug = `${newSlug}-${counter}`;
+        }
+        
+        newSlug = uniqueSlug;
+      }
+    }
+
     // Update the recipe with a transaction to handle tags
     const updatedRecipe = await prisma.$transaction(async (tx) => {
       // Delete existing tags
@@ -131,6 +156,7 @@ export async function PUT(
         where: { id },
         data: {
           title,
+          slug: newSlug,
           instructions,
           tags: {
             create: tags.map(tagName => ({

--- a/src/app/recipes/[slug]/page.tsx
+++ b/src/app/recipes/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
 import Link from 'next/link';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
 import { slugify } from '@/lib/utils';
@@ -10,7 +10,15 @@ import TagPill from '@/components/ui/TagPill';
 import { CopyLinkButton } from '@/components/CopyLinkButton';
 import Head from 'next/head';
 
-async function getRecipeWithInteractions(slug: string, userId?: string) {
+type RecipeData = {
+  recipe: any;
+  userInteractions: any;
+  navigation: any;
+} | {
+  redirect: string;
+} | null;
+
+async function getRecipeWithInteractions(slug: string, userId?: string): Promise<RecipeData> {
   try {
     const recipe = await prisma.recipe.findUnique({
       where: { slug },
@@ -25,7 +33,37 @@ async function getRecipeWithInteractions(slug: string, userId?: string) {
         },
       },
     });
+    
     if (!recipe) {
+      // Try to find a recipe with a similar title that might have been renamed
+      // This handles cases where the slug changed but the title is similar
+      const possibleRecipes = await prisma.recipe.findMany({
+        where: {
+          OR: [
+            { title: { contains: slug.replace(/-/g, ' '), mode: 'insensitive' } },
+            { title: { contains: slug.replace(/-/g, ''), mode: 'insensitive' } },
+          ]
+        },
+        include: {
+          author: true,
+          tags: true,
+          _count: {
+            select: {
+              votes: true,
+              tried: true,
+            },
+          },
+        },
+        take: 1,
+      });
+      
+      if (possibleRecipes.length > 0) {
+        // Redirect to the found recipe
+        const foundRecipe = possibleRecipes[0];
+        console.log(`Redirecting from old slug "${slug}" to "${foundRecipe.slug}" for recipe "${foundRecipe.title}"`);
+        return { redirect: `/recipes/${foundRecipe.slug}` };
+      }
+      
       return null;
     }
 
@@ -126,6 +164,11 @@ export default async function RecipePage({ params }: { params: Promise<{ slug: s
 
   if (!recipeData) {
     notFound();
+  }
+
+  // Handle redirect case
+  if ('redirect' in recipeData) {
+    redirect(recipeData.redirect);
   }
 
   const { recipe, userInteractions, navigation } = recipeData;
@@ -234,7 +277,7 @@ export default async function RecipePage({ params }: { params: Promise<{ slug: s
                 {/* Tags */}
                 {recipe.tags.length > 0 && (
                   <div className="flex flex-wrap gap-2">
-                    {recipe.tags.map((tag) => (
+                    {recipe.tags.map((tag: { id: string; name: string }) => (
                       <TagPill
                         key={tag.id}
                         tag={tag.name}

--- a/src/components/recipes/RecipeForm.tsx
+++ b/src/components/recipes/RecipeForm.tsx
@@ -211,8 +211,11 @@ export default function RecipeForm({ recipe, isEditing = false }: RecipeFormProp
       }
 
       const createdRecipe = await response.json();
-      const slug = createdRecipe.slug || (createdRecipe.recipe && createdRecipe.recipe.slug);
+      
+      // For both create and update, use the slug from the response
+      const slug = createdRecipe.slug;
       if (!slug) throw new Error('No slug returned from server');
+      
       router.push(`/recipes/${slug}`);
       router.refresh();
     } catch (err) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,11 +8,16 @@
  * @returns A URL-friendly slug
  */
 export function slugify(text: string): string {
+  if (!text || typeof text !== 'string') {
+    return '';
+  }
+  
   return text
     .toLowerCase()
     .replace(/[^\w\s-]/g, '') // Remove special characters
     .replace(/\s+/g, '-') // Replace spaces with hyphens
     .replace(/-+/g, '-') // Replace multiple hyphens with a single hyphen
+    .replace(/^-+|-+$/g, '') // Remove leading and trailing hyphens
     .trim();
 }
 


### PR DESCRIPTION
- Add automatic slug regeneration in recipe update API
- Implement conflict resolution for duplicate slugs
- Improve slugify function with better edge case handling
- Add legacy URL support with intelligent redirects
- Fix existing problematic recipe slug
- Update frontend to handle slug changes properly

Resolves issue where changing recipe titles didn't update URLs